### PR TITLE
[FIX] vue.config.jsの設定とそれに伴うリクエストのURLの変更

### DIFF
--- a/app/javascript/store/modules/hotPepperGourmand.js
+++ b/app/javascript/store/modules/hotPepperGourmand.js
@@ -9,7 +9,7 @@ const testConfig = {
     lng: "135.52",
     range: "5",
     order: "4",
-    format: "json",
+    format: "jsonp",
   },
 };
 

--- a/app/javascript/store/modules/hotPepperGourmand.js
+++ b/app/javascript/store/modules/hotPepperGourmand.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 
-const HOTPEPPER_API_ENDPOINT =
-  "http://webservice.recruit.co.jp/hotpepper/gourmet/v1/";
+const HOTPEPPER_API_ENDPOINT = "/api/hotpepper/gourmet/v1/";
 
 const testConfig = {
   params: {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,8 +1,10 @@
 module.exports = {
-  devServer: {
-    proxy: {
-      "/api": {
-        target: "http://webservice.recruit.co.jp",
+  configureWebpack: {
+    devServer: {
+      proxy: {
+        "/api": {
+          target: "http://webservice.recruit.co.jp",
+        },
       },
     },
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  devServer: {
+    proxy: {
+      "/api": {
+        target: "http://webservice.recruit.co.jp",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## issue
#35 
対象ファイルの変更後サーバーを再起動して実行した
**実行結果**
リクエスト先が期待したURLと異なる
 → ```vue.config.js``` の設定が反映されていない
<img width="1021" alt="Screenshot 2022-04-07 15 42 38" src="https://user-images.githubusercontent.com/95160084/162136750-85425ecd-d61e-40c4-a029-ceb0c4f62987.png">

[19bf8e7](https://github.com/ky0613/cheat_day_master/pull/37/commits/19bf8e7875cc42fdfe3fcb21e628662e9757f8a7)
レスポンスの形式が原因の可能性があるため，上記コミットにてレスポンスの形式をjsonからjsonpに変更した。
**実行結果**
エラーは発生しなくなったがレスポンスはindex.htmlが返ってくるようになった。
もともとの形式であるXML形式で試しても同様の現象が起きた。
リクエスト
<img width="905" alt="Screenshot 2022-04-07 16 00 40" src="https://user-images.githubusercontent.com/95160084/162139288-8a442a8e-f219-40b0-8441-bd8ac4cc5a36.png">
レスポンス
<img width="1012" alt="Screenshot 2022-04-07 16 01 28" src="https://user-images.githubusercontent.com/95160084/162139387-af18d3c2-dd42-42ee-ad8b-f44d2bf746a4.png">

[10f92d7](https://github.com/ky0613/cheat_day_master/pull/37/commits/10f92d7710e1856527e9a0aaa4515f466338b7d3)
下記された記事を参考にvue.config.js内を変更した
[working-with-webpack](https://cli.vuejs.org/guide/webpack.html#working-with-webpack)
結果は上記のまま変わらず